### PR TITLE
rework renderer

### DIFF
--- a/src/demo_0.py
+++ b/src/demo_0.py
@@ -141,7 +141,7 @@ def make_scene(canvas_dimension: int) -> Scene:
     return scene
 
 
-def render(
+def render(  # pylint: disable=R0913
     scene: Scene,
     geometry: Geometry,
     render_ray_depth: bool,

--- a/src/demo_1.py
+++ b/src/demo_1.py
@@ -141,7 +141,7 @@ def make_scene(canvas_dimension: int) -> Scene:
     return scene
 
 
-def render(
+def render(  # pylint: disable=R0913
     scene: Scene,
     geometry: Geometry,
     render_ray_depth: bool,

--- a/src/demo_2.py
+++ b/src/demo_2.py
@@ -110,7 +110,7 @@ def make_scene(canvas_dimension: int) -> Scene:
     return scene
 
 
-def render(
+def render(  # pylint: disable=R0913
     scene: Scene,
     geometry: Geometry,
     render_ray_depth: bool,

--- a/src/demo_2.py
+++ b/src/demo_2.py
@@ -124,7 +124,6 @@ def render(  # pylint: disable=R0913
     """
 
     for projection_mode in ProjectionMode:
-        # for mode in (ImageRenderer.Mode.PERSPECTIVE,):
         print(f"rendering {projection_mode.name} projection ...")
         if render_ray_depth:
             image_renderer: ImageRenderer = ImageRayDepthRenderer(

--- a/src/demo_3.py
+++ b/src/demo_3.py
@@ -1,0 +1,195 @@
+"""
+Demonstartes the image filter renderer with an example scene in cylindrical
+coordinates an various filters.
+"""
+
+import os
+import math
+
+from nerte.values.coordinates import Coordinates3D
+from nerte.values.domain import Domain1D
+from nerte.values.linalg import AbstractVector
+from nerte.values.face import Face
+from nerte.values.manifolds.cylindrical import (
+    Plane as CarthesianPlaneInCylindric,
+)
+from nerte.world.object import Object
+from nerte.world.camera import Camera
+from nerte.world.scene import Scene
+from nerte.geometry.geometry import Geometry
+from nerte.geometry.cylindircal_swirl_geometry import (
+    SwirlCylindricRungeKuttaGeometry,
+)
+from nerte.render.projection import ProjectionMode
+from nerte.render.image_filter_renderer import (
+    ImageFilterRenderer,
+    Filter,
+    HitFilter,
+)
+from nerte.render.ray_depth_filter import RayDepthFilter
+from nerte.util.random_color_generator import RandomColorGenerator
+
+# pseudo-random color generator
+COLOR = RandomColorGenerator()
+
+
+def make_camera(canvas_dimension: int) -> Camera:
+    """Creates a camera with preset values."""
+
+    location = Coordinates3D((2.0, 0.0, 2.0))
+    manifold = CarthesianPlaneInCylindric(
+        b0=AbstractVector((0.0, -1.0, 0.0)),
+        b1=AbstractVector((-0.4, 0.0, 0.4)),
+        x0_domain=Domain1D(-1.0, +1.0),
+        x1_domain=Domain1D(-1.0, +1.0),
+        offset=AbstractVector((1.5, 0.0, 1.5)),
+    )
+    camera = Camera(
+        location=location,
+        detector_manifold=manifold,
+        canvas_dimensions=(canvas_dimension, canvas_dimension),
+    )
+    return camera
+
+
+def add_cylinder(scene: Scene, radius: float, height: float) -> None:
+    """Adds a cylinder at the center of the scene."""
+
+    # cylinder
+    # top 1
+    point0 = Coordinates3D((0.0, -math.pi, +height))
+    point1 = Coordinates3D((radius, -math.pi, +height))
+    point2 = Coordinates3D((radius, math.pi, +height))
+    tri = Face(point0, point1, point2)
+    obj = Object(color=next(COLOR))  # pseudo-random color
+    obj.add_face(tri)
+    scene.add_object(obj)
+    # top 2
+    point0 = Coordinates3D((0.0, -math.pi, +height))
+    point1 = Coordinates3D((0.0, +math.pi, +height))
+    point2 = Coordinates3D((radius, +math.pi, +height))
+    tri = Face(point0, point1, point2)
+    obj = Object(color=next(COLOR))  # pseudo-random color
+    obj.add_face(tri)
+    scene.add_object(obj)
+    # side 1
+    point0 = Coordinates3D((radius, -math.pi, -height))
+    point1 = Coordinates3D((radius, -math.pi, +height))
+    point2 = Coordinates3D((radius, +math.pi, +height))
+    tri = Face(point0, point1, point2)
+    obj = Object(color=next(COLOR))  # pseudo-random color
+    obj.add_face(tri)
+    scene.add_object(obj)
+    # side 2
+    point0 = Coordinates3D((radius, -math.pi, -height))
+    point1 = Coordinates3D((radius, +math.pi, -height))
+    point2 = Coordinates3D((radius, +math.pi, +height))
+    tri = Face(point0, point1, point2)
+    obj = Object(color=next(COLOR))  # pseudo-random color
+    obj.add_face(tri)
+    scene.add_object(obj)
+    # bottom 1
+    point0 = Coordinates3D((0.0, -math.pi, -height))
+    point1 = Coordinates3D((radius, -math.pi, -height))
+    point2 = Coordinates3D((radius, +math.pi, -height))
+    tri = Face(point0, point1, point2)
+    obj = Object(color=next(COLOR))  # pseudo-random color
+    obj.add_face(tri)
+    scene.add_object(obj)
+    # bottom 2
+    point0 = Coordinates3D((0.0, -math.pi, -height))
+    point1 = Coordinates3D((0.0, +math.pi, -height))
+    point2 = Coordinates3D((radius, +math.pi, -height))
+    tri = Face(point0, point1, point2)
+    obj = Object(color=next(COLOR))  # pseudo-random color
+    obj.add_face(tri)
+    scene.add_object(obj)
+
+
+def make_scene(canvas_dimension: int) -> Scene:
+    """
+    Creates a scene with a camera pointing towards an object.
+    """
+
+    camera = make_camera(canvas_dimension=canvas_dimension)
+    scene = Scene(camera=camera)
+    add_cylinder(scene, radius=1.0, height=1.0)
+
+    return scene
+
+
+def render(  # pylint: disable=R0913
+    scene: Scene,
+    geometry: Geometry,
+    filtr: Filter,
+    output_path: str,
+    file_prefix: str,
+    show: bool,
+) -> None:
+    """
+    Renders a preset scene with non-euclidean geometry in orthographic and
+    perspective projection.
+    """
+
+    for projection_mode in ProjectionMode:
+        # for mode in (ImageRenderer.Mode.PERSPECTIVE,):
+        print(f"rendering {projection_mode.name} projection ...")
+        renderer = ImageFilterRenderer(
+            projection_mode=projection_mode,
+            filtr=filtr,
+            print_warings=False,
+        )
+        renderer.render(scene=scene, geometry=geometry)
+        renderer.apply_filter()
+        os.makedirs(output_path, exist_ok=True)
+        image = renderer.last_image()
+        if image is not None:
+            image.save(
+                f"{output_path}/{file_prefix}_{projection_mode.name}.png"
+            )
+            if show:
+                image.show()
+
+
+def main() -> None:
+    """Creates and renders the demo scene."""
+
+    # NOTE: Increase the canvas dimension to improve the image quality.
+    #       This will also increase rendering time!
+    scene = make_scene(canvas_dimension=100)
+    geo = SwirlCylindricRungeKuttaGeometry(
+        max_ray_depth=math.inf,
+        step_size=0.5,
+        max_steps=25,
+        swirl_strength=0.25,
+    )
+
+    output_path = "../images"
+    file_prefix = "demo3"
+    show = True  # disable if images cannot be displayed
+
+    # hit filter
+    filtr: Filter = HitFilter()
+    render(
+        scene=scene,
+        geometry=geo,
+        filtr=filtr,
+        output_path=output_path,
+        file_prefix=file_prefix + "_hit_filter",
+        show=show,
+    )
+
+    # ray depth filter
+    filtr = RayDepthFilter()
+    render(
+        scene=scene,
+        geometry=geo,
+        filtr=filtr,
+        output_path=output_path,
+        file_prefix=file_prefix + "_ray_depth_filter",
+        show=show,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nerte/geometry/runge_kutta_geometry.py
+++ b/src/nerte/geometry/runge_kutta_geometry.py
@@ -21,6 +21,7 @@ from nerte.values.ray_segment_delta import (
     add_ray_segment_delta,
 )
 from nerte.values.intersection_info import IntersectionInfo, IntersectionInfos
+from nerte.values.extended_intersection_info import ExtendedIntersectionInfo
 from nerte.geometry.geometry import Geometry, intersection_ray_depth
 
 
@@ -165,7 +166,9 @@ class RungeKuttaGeometry(Geometry):
                 )
                 if relative_segment_depth < math.inf:
                     total_ray_depth += relative_segment_depth * segment_length
-                    return IntersectionInfo(ray_depth=total_ray_depth)
+                    return ExtendedIntersectionInfo(
+                        ray_depth=total_ray_depth, meta_data={"steps": step + 1}
+                    )
 
                 step += 1
                 total_ray_depth += segment_length

--- a/src/nerte/geometry/runge_kutta_geometry_unittest.py
+++ b/src/nerte/geometry/runge_kutta_geometry_unittest.py
@@ -7,7 +7,7 @@
 
 import unittest
 
-from typing import Callable, Type, TypeVar
+from typing import Callable, Type, TypeVar, cast
 
 from itertools import permutations
 import math
@@ -20,6 +20,7 @@ from nerte.values.ray_segment import RaySegment
 from nerte.values.ray_segment_delta import RaySegmentDelta
 from nerte.values.face import Face
 from nerte.values.intersection_info import IntersectionInfo
+from nerte.values.extended_intersection_info import ExtendedIntersectionInfo
 from nerte.values.util.convert import coordinates_as_vector
 from nerte.geometry.runge_kutta_geometry import RungeKuttaGeometry
 
@@ -385,6 +386,51 @@ class RungeKuttaGeometryRayIntersectsRayLeftManifoldImmediatelyTest(
                 info.miss_reason(),
                 IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD,
             )
+
+
+class RungeKuttaGeometryRayIntersectsMetaDataTest(GeometryTestCase):
+    def setUp(self) -> None:
+        p1 = Coordinates3D((1.0, 0.0, 0.0))
+        p2 = Coordinates3D((0.0, 1.0, 0.0))
+        p3 = Coordinates3D((0.0, 0.0, 1.0))
+        self.face = Face(p1, p2, p3)
+        # geometry (carthesian & euclidean)
+        DummyRungeKuttaGeometryGeo = _make_dummy_runge_kutta_geometry()
+        geos = (
+            DummyRungeKuttaGeometryGeo(
+                max_ray_depth=1000.0,
+                step_size=1,  # direct hit
+                max_steps=100,
+            ),
+            DummyRungeKuttaGeometryGeo(
+                max_ray_depth=1000.0,
+                step_size=0.1,  # 6 steps until hit (1/sqrt(3) ~ 0.577...)
+                max_steps=100,
+            ),
+        )
+        self.rays = tuple(
+            geo.ray_from_tangent(
+                start=Coordinates3D((0.0, 0.0, 0.0)),
+                direction=AbstractVector((1.0, 1.0, 1.0)),
+            )
+            for geo in geos
+        )
+        self.steps = (1, 6)
+
+    def test_runge_kutta_geometry_intersects_meta_data(self) -> None:
+        """
+        Tests if ray's meta data.
+        """
+        for ray, steps in zip(self.rays, self.steps):
+            info = ray.intersection_info(self.face)
+            self.assertIsInstance(info, ExtendedIntersectionInfo)
+            if isinstance(info, ExtendedIntersectionInfo):
+                info = cast(ExtendedIntersectionInfo, info)
+                meta_data = info.meta_data
+                self.assertIsNotNone(meta_data)
+                if meta_data is not None:
+                    self.assertTrue("steps" in meta_data)
+                    self.assertAlmostEqual(meta_data["steps"], steps)
 
 
 class DummyRungeKuttaGeometryRayFromTest(GeometryTestCase):

--- a/src/nerte/geometry/segmented_ray_geometry.py
+++ b/src/nerte/geometry/segmented_ray_geometry.py
@@ -14,6 +14,7 @@ from nerte.values.face import Face
 from nerte.values.linalg import AbstractVector
 from nerte.values.ray_segment import RaySegment
 from nerte.values.intersection_info import IntersectionInfo, IntersectionInfos
+from nerte.values.extended_intersection_info import ExtendedIntersectionInfo
 from nerte.geometry.geometry import Geometry, intersection_ray_depth
 
 
@@ -113,7 +114,9 @@ class SegmentedRayGeometry(Geometry):
                     total_ray_depth = (
                         step + relative_segment_ray_depth
                     ) * geometry.ray_segment_length()
-                    return IntersectionInfo(ray_depth=total_ray_depth)
+                    return ExtendedIntersectionInfo(
+                        ray_depth=total_ray_depth, meta_data={"steps": step + 1}
+                    )
 
             return IntersectionInfos.NO_INTERSECTION
 

--- a/src/nerte/render/image_filter_renderer.py
+++ b/src/nerte/render/image_filter_renderer.py
@@ -1,0 +1,307 @@
+"""
+Module for rendering a scene with respect to a geometry.
+The data is rendered first and filters may be applied afterwards.
+"""
+
+from typing import Optional, NewType
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+from PIL import Image
+
+from nerte.values.color import Color
+from nerte.values.intersection_info import IntersectionInfo, IntersectionInfos
+from nerte.world.camera import Camera
+from nerte.world.object import Object
+from nerte.world.scene import Scene
+from nerte.geometry.geometry import Geometry
+from nerte.render.image_renderer import ImageRenderer
+from nerte.render.projection import ProjectionMode
+
+# TODO: provide proper container type
+IntersectionInfoMatrix = NewType(
+    "IntersectionInfoMatrix", list[list[IntersectionInfo]]
+)
+
+
+class Filter(ABC):
+    """
+    Interface for filters which convert the raw intersctio information of a
+    ray into a color
+
+    The workflow has two stages:
+    1) The data is analyzed. e.g. to determine the color map.
+    2) The color information is requested on a per pixel basis.
+    ."""
+
+    @abstractmethod
+    def analyze(
+        self,
+        info_matrix: IntersectionInfoMatrix,
+        canvas_dimensions: tuple[int, int],
+    ) -> None:
+        """Initialize mapping from intersection info matrix to colors."""
+        # pylint: disable=W0107
+        pass
+
+    @abstractmethod
+    def color_for_pixel(
+        self,
+        info_matrix: IntersectionInfoMatrix,
+        canvas_dimensions: tuple[int, int],
+        pixel_location: tuple[int, int],
+    ) -> Color:
+        """
+        Returns color for pixel based.
+
+        WARNING: Results are only valid if analyze was run first.
+        """
+        # pylint: disable=W0107
+        pass
+
+
+class HitFilter(Filter):
+    """
+    False color filter for displaying rays based on whether they hit a surface
+    or missed it.
+
+    The details about the miss are encoded into (unique) colors.
+    """
+
+    def color_hit(self) -> Color:
+        """Returns a color for a pixel to denote a ray hitting a surface."""
+        # pylint: disable=R0201
+        return Color(128, 128, 128)
+
+    def color_miss_reason(
+        self, miss_reason: IntersectionInfo.MissReason
+    ) -> Color:
+        """
+        Returns a color for a pixel to denote a ray failing to hit a surface.
+        """
+        # pylint: disable=R0201
+        if miss_reason is IntersectionInfo.MissReason.UNINIALIZED:
+            return Color(0, 0, 0)
+        if miss_reason is IntersectionInfo.MissReason.NO_INTERSECTION:
+            return Color(0, 0, 255)
+        if miss_reason is IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD:
+            return Color(0, 255, 0)
+        if (
+            miss_reason
+            is IntersectionInfo.MissReason.RAY_INITIALIZED_OUTSIDE_MANIFOLD
+        ):
+            return Color(255, 255, 0)
+        raise NotImplementedError(
+            f"Cannot pick color for miss reason {miss_reason}."
+            f"No color was implemented."
+        )
+
+    def analyze(
+        self,
+        info_matrix: IntersectionInfoMatrix,
+        canvas_dimensions: tuple[int, int],
+    ) -> None:
+        pass
+
+    def color_for_pixel(
+        self,
+        info_matrix: IntersectionInfoMatrix,
+        canvas_dimensions: tuple[int, int],
+        pixel_location: tuple[int, int],
+    ) -> Color:
+        pixel_x, pixel_y = pixel_location
+        info = info_matrix[pixel_x][pixel_y]
+        if info.hits():
+            return self.color_hit()
+        miss_reason = info.miss_reason()
+        if miss_reason is None:
+            raise RuntimeError(
+                f"Cannot pick color for pixel {pixel_location}."
+                " No miss reason specified despite missing."
+            )
+        return self.color_miss_reason(miss_reason)
+
+
+class ImageFilterRenderer(ImageRenderer):
+    """
+    Renderer which renders the data first and allows to apply filters after.
+
+    This workflow costs more resources during rendering but also allows for
+    more experimentation.
+    """
+
+    def __init__(
+        self,
+        projection_mode: ProjectionMode,
+        filtr: Filter,
+        print_warings: bool = True,
+        auto_apply_filter: bool = True,
+    ):
+
+        ImageRenderer.__init__(
+            self, projection_mode, print_warings=print_warings
+        )
+
+        self._filter = filtr
+        self.auto_apply_filter = auto_apply_filter
+        self._last_canvas_dimensions: Optional[tuple[int, int]] = None
+        self._last_info_matrix: Optional[IntersectionInfoMatrix] = None
+
+    def has_render_data(self) -> bool:
+        """Returns True, iff render was called previously."""
+
+        return (
+            self._last_canvas_dimensions is not None
+            and self._last_canvas_dimensions is not None
+        )
+
+    def filter(self) -> Filter:
+        """Returns the filter currently used."""
+        return self._filter
+
+    def change_filter(self, filtr: Filter) -> None:
+        """
+        Changes the filter to a new one.
+
+        Note: This may cause the filter to be applied automatically if
+              auto_apply_filter is enabled. Otherwise apply_filter must be
+              called manually to apply the filter. Results may be outdated
+              until then.
+        """
+        self._filter = filtr
+        if self.auto_apply_filter and self.has_render_data():
+            self.apply_filter()
+
+    def render_pixel_intersection_info(
+        self,
+        camera: Camera,
+        geometry: Geometry,
+        objects: list[Object],
+        pixel_location: tuple[int, int],
+    ) -> IntersectionInfo:
+        """
+        Returns the intersection info of the ray cast for the pixel.
+        """
+
+        ray = self.ray_for_pixel(camera, geometry, pixel_location)
+        if ray is None:
+            return IntersectionInfos.RAY_INITIALIZED_OUTSIDE_MANIFOLD
+
+        # detect intersections with objects
+        current_depth = np.inf
+        current_info = IntersectionInfos.NO_INTERSECTION
+        for obj in objects:
+            for face in obj.faces():
+                intersection_info = ray.intersection_info(face)
+                if intersection_info.hits():
+                    # update intersection info to closest
+                    if intersection_info.ray_depth() < current_depth:
+                        current_depth = intersection_info.ray_depth()
+                        current_info = intersection_info
+                else:
+                    # update intersection info to ray left manifold
+                    # if no face was intersected yet and ray left manifold
+                    if (
+                        current_info is IntersectionInfos.NO_INTERSECTION
+                        and intersection_info.miss_reason()
+                        is IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD
+                    ):
+                        current_info = IntersectionInfos.RAY_LEFT_MANIFOLD
+        return current_info
+
+    def render_intersection_info(
+        self, scene: Scene, geometry: Geometry
+    ) -> IntersectionInfoMatrix:
+        """
+        Returns matrix with intersection infos per pixel.
+        """
+
+        width, height = scene.camera.canvas_dimensions
+        # initialize background with nan
+        info_matrix: IntersectionInfoMatrix = IntersectionInfoMatrix(
+            [
+                [IntersectionInfos.UNINIALIZED for _ in range(height)]
+                for _ in range(width)
+            ]
+        )
+        # obtain pixel ray info
+        for pixel_x in range(width):
+            for pixel_y in range(height):
+                pixel_location = (pixel_x, pixel_y)
+                pixel_info = self.render_pixel_intersection_info(
+                    scene.camera,
+                    geometry,
+                    scene.objects(),
+                    pixel_location,
+                )
+                info_matrix[pixel_x][pixel_y] = pixel_info
+        return info_matrix
+
+    def render(self, scene: Scene, geometry: Geometry) -> None:
+        """
+        Renders ray intersection information.
+
+        First stage in processing. Apply a filter next.
+
+        Note: Filter may be applied automatically if auto_apply_filter is True.
+              Else apply_filter must be called manually.
+        """
+        # obtain ray depth information and normalize it
+        info_matrix = self.render_intersection_info(
+            scene=scene, geometry=geometry
+        )
+        self._last_canvas_dimensions = scene.camera.canvas_dimensions
+        self._last_info_matrix = info_matrix
+
+        if self.auto_apply_filter:
+            self.apply_filter()
+
+    def apply_filter(self) -> None:
+        """
+        Convert intersection information into an image.
+
+        Second and last stage in processing. Must have rendererd first.
+
+        Note: This method may be called automatically depending on
+              auto_apply_filter. If not apply_filter must be called manually.
+        """
+
+        if self._last_canvas_dimensions is None:
+            print(
+                "WARNING: Cannot apply filter without rendering first."
+                " No canvas dimensions found."
+            )
+            return
+        if self._last_info_matrix is None:
+            print(
+                "WARNING: Cannot apply filter without rendering first."
+                " No intersection info matrix found."
+            )
+            return
+
+        width, height = self._last_canvas_dimensions
+        # initialize image with pink background
+        image = Image.new(
+            mode="RGB", size=(width, height), color=self.color_failure().rgb
+        )
+        self._filter.analyze(
+            info_matrix=self._last_info_matrix,
+            canvas_dimensions=self._last_canvas_dimensions,
+        )
+
+        # paint in pixels
+        for pixel_x in range(width):
+            for pixel_y in range(height):
+                pixel_location = (pixel_x, pixel_y)
+                pixel_color = self._filter.color_for_pixel(
+                    info_matrix=self._last_info_matrix,
+                    canvas_dimensions=self._last_canvas_dimensions,
+                    pixel_location=pixel_location,
+                )
+                image.putpixel(pixel_location, pixel_color.rgb)
+        self._last_image = image
+
+    def last_image(self) -> Optional[Image.Image]:
+        """Returns the last image rendered iff it exists or else None."""
+        return self._last_image

--- a/src/nerte/render/image_filter_renderer_unittest.py
+++ b/src/nerte/render/image_filter_renderer_unittest.py
@@ -1,0 +1,569 @@
+# pylint: disable=R0801
+# pylint: disable=C0103
+# pylint: disable=C0114
+# pylint: disable=C0115
+# pylint: disable=C0144
+
+import unittest
+
+import math
+
+from nerte.values.coordinates import Coordinates3D
+from nerte.values.domain import Domain1D
+from nerte.values.linalg import AbstractVector
+from nerte.values.manifolds.cartesian import Plane
+from nerte.values.manifolds.cylindrical import Plane as PlaneCylindrical
+from nerte.values.face import Face
+from nerte.values.intersection_info import IntersectionInfo, IntersectionInfos
+from nerte.values.color import Color, Colors
+from nerte.world.object import Object
+from nerte.world.camera import Camera
+from nerte.world.scene import Scene
+from nerte.geometry.carthesian_geometry import CarthesianGeometry
+from nerte.geometry.cylindircal_geometry import CylindricRungeKuttaGeometry
+from nerte.render.projection import ProjectionMode
+from nerte.render.image_filter_renderer import (
+    IntersectionInfoMatrix,
+    Filter,
+    HitFilter,
+    ImageFilterRenderer,
+)
+
+
+class FilterImplentationTest(unittest.TestCase):
+    def test_implementation(self) -> None:
+        # pylint: disable=R0201
+        """Tests the implementation of the interface."""
+
+        class DummyFilter(Filter):
+            def analyze(
+                self,
+                info_matrix: IntersectionInfoMatrix,
+                canvas_dimensions: tuple[int, int],
+            ) -> None:
+                pass
+
+            def color_for_pixel(
+                self,
+                info_matrix: IntersectionInfoMatrix,
+                canvas_dimensions: tuple[int, int],
+                pixel_location: tuple[int, int],
+            ) -> Color:
+                return Colors.BLACK
+
+        DummyFilter()
+
+
+class HitFilterConstructorTest(unittest.TestCase):
+    def test_constructor(self) -> None:
+        # pylint: disable=R0201
+        """Tests the constructor."""
+        HitFilter()
+
+
+class HitFilterColorsrTest(unittest.TestCase):
+    def assertAllColorsUnique(self, colors: list[Color]) -> None:
+        """ "Asserts all colors in the list are unique."""
+
+        def all_unique(colors: list[Color]) -> bool:
+            rgbs = []
+            return not any(
+                any(c.rgb == rgb for rgb in rgbs)
+                or rgbs.append(c.rgb)  # type: ignore[func-returns-value]
+                for c in colors
+            )
+
+        try:
+            self.assertTrue(all_unique(colors))
+        except AssertionError as ae:
+            raise AssertionError(
+                f"Colors in list {colors} are not unique."
+            ) from ae
+
+    def setUp(self) -> None:
+        self.filter = HitFilter()
+
+    def test_colors(self) -> None:
+        # pylint: disable=R0201
+        """Tests the colors."""
+        colors: list[Color] = []
+        colors.append(self.filter.color_hit())
+        colors.append(
+            self.filter.color_miss_reason(
+                IntersectionInfo.MissReason.UNINIALIZED
+            )
+        )
+        colors.append(
+            self.filter.color_miss_reason(
+                IntersectionInfo.MissReason.NO_INTERSECTION
+            )
+        )
+        colors.append(
+            self.filter.color_miss_reason(
+                IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD
+            )
+        )
+        colors.append(
+            self.filter.color_miss_reason(
+                IntersectionInfo.MissReason.RAY_INITIALIZED_OUTSIDE_MANIFOLD
+            )
+        )
+
+        self.assertTrue(len(colors) == 5)
+        self.assertAllColorsUnique(colors)
+
+
+class HitFilterAnalyzeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        infos = (
+            IntersectionInfo(ray_depth=1.0),
+            IntersectionInfos.UNINIALIZED,
+            IntersectionInfos.NO_INTERSECTION,
+            IntersectionInfos.RAY_LEFT_MANIFOLD,
+            IntersectionInfos.RAY_INITIALIZED_OUTSIDE_MANIFOLD,
+        )
+        self.info_matrices = tuple(
+            IntersectionInfoMatrix([[info]]) for info in infos
+        )
+        self.filter = HitFilter()
+
+    def test_analyze(self) -> None:
+        """Tests analyze."""
+        for info_mat in self.info_matrices:
+            self.filter.analyze(info_matrix=info_mat, canvas_dimensions=(1, 1))
+
+
+class HitFilterColorForPixelTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.infos = (
+            IntersectionInfo(ray_depth=1.0),
+            IntersectionInfos.UNINIALIZED,
+            IntersectionInfos.NO_INTERSECTION,
+            IntersectionInfos.RAY_LEFT_MANIFOLD,
+            IntersectionInfos.RAY_INITIALIZED_OUTSIDE_MANIFOLD,
+        )
+        self.info_matrices = tuple(
+            IntersectionInfoMatrix([[info]]) for info in self.infos
+        )
+        self.filter = HitFilter()
+
+    def test_color_for_pixel(self) -> None:
+        """Test color for pixel correct based on intersection info."""
+        for info, info_mat in zip(self.infos, self.info_matrices):
+            self.filter.analyze(info_matrix=info_mat, canvas_dimensions=(1, 1))
+            pixel_color = self.filter.color_for_pixel(
+                info_matrix=info_mat,
+                canvas_dimensions=(1, 1),
+                pixel_location=(0, 0),
+            )
+            if info.hits():
+                info_color = self.filter.color_hit()
+            else:
+                miss_reason = info.miss_reason()
+                self.assertIsNotNone(miss_reason)  # precondition
+                if miss_reason is not None:
+                    info_color = self.filter.color_miss_reason(miss_reason)
+            self.assertTrue(pixel_color.rgb == info_color.rgb)
+
+
+class ImageFilterRendererConstructorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.filter = HitFilter()
+
+    def test_image_filter_renderer_costructor(self) -> None:
+        """Tests the constructor."""
+
+        for mode in ProjectionMode:
+            ImageFilterRenderer(projection_mode=mode, filtr=self.filter)
+
+
+class ImageFilterRendererPropertiesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # filter
+        self.filter = HitFilter()
+
+    def test_image_filter_renderer_costructor(self) -> None:
+        """Tests the initial properties."""
+
+        for mode in ProjectionMode:
+            renderer = ImageFilterRenderer(
+                projection_mode=mode, filtr=self.filter
+            )
+            self.assertFalse(renderer.has_render_data())
+            self.assertIsNone(renderer.last_image())
+            self.assertIs(renderer.filter(), self.filter)
+
+
+class ImageFilterRendererChangeFilterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # filters
+        self.filter1 = HitFilter()
+        self.filter2 = HitFilter()
+        self.renderers_with_auto_apply = tuple(
+            ImageFilterRenderer(projection_mode=mode, filtr=self.filter1)
+            for mode in ProjectionMode
+        )
+        self.renderers_without_auto_apply = tuple(
+            ImageFilterRenderer(
+                projection_mode=mode,
+                filtr=self.filter1,
+                auto_apply_filter=False,
+            )
+            for mode in ProjectionMode
+        )
+
+    def test_image_filter_renderer_change_filter(self) -> None:
+        """Tests basics of filter change."""
+
+        for renderer in self.renderers_with_auto_apply:
+            self.assertIs(renderer.filter(), self.filter1)
+            renderer.change_filter(self.filter2)
+            self.assertIs(renderer.filter(), self.filter2)
+        for renderer in self.renderers_without_auto_apply:
+            self.assertIs(renderer.filter(), self.filter1)
+            renderer.change_filter(self.filter2)
+            self.assertIs(renderer.filter(), self.filter2)
+
+
+class ImageFilterRendererAutoApplyFilterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # camera
+        loc = Coordinates3D((0.0, 0.0, -1.0))
+        domain = Domain1D(-1.0, 1.0)
+        manifold = Plane(
+            AbstractVector((1.0, 0.0, 0.0)),
+            AbstractVector((0.0, 1.0, 0.0)),
+            x0_domain=domain,
+            x1_domain=domain,
+        )
+        dim = 10
+        cam = Camera(
+            location=loc,
+            detector_manifold=manifold,
+            canvas_dimensions=(dim, dim),
+        )
+        # scene
+        self.scene = Scene(camera=cam)
+        # geometry
+        self.geometry = CarthesianGeometry()
+        # filters
+        self.filter1 = HitFilter()
+        self.filter2 = HitFilter()
+        self.renderers_with_auto_apply = tuple(
+            ImageFilterRenderer(projection_mode=mode, filtr=self.filter1)
+            for mode in ProjectionMode
+        )
+        self.renderers_without_auto_apply = tuple(
+            ImageFilterRenderer(
+                projection_mode=mode,
+                filtr=self.filter1,
+                auto_apply_filter=False,
+            )
+            for mode in ProjectionMode
+        )
+
+    def test_image_filter_renderer_change_filter_with_auto_apply(self) -> None:
+        """Tests change filter with auto apply enabled."""
+
+        for renderer in self.renderers_with_auto_apply:
+            self.assertIsNone(renderer.last_image())
+            renderer.change_filter(self.filter2)
+            self.assertIsNone(renderer.last_image())
+            renderer.render(scene=self.scene, geometry=self.geometry)
+            img2 = renderer.last_image()
+            self.assertIsNotNone(img2)
+            renderer.change_filter(self.filter1)
+            img1 = renderer.last_image()
+            self.assertIsNotNone(img1)
+            self.assertIsNot(img1, img2)
+
+    def test_image_filter_renderer_change_filter_without_auto_apply(
+        self,
+    ) -> None:
+        """Tests change filter with auto apply disabled."""
+
+        for renderer in self.renderers_without_auto_apply:
+            self.assertIsNone(renderer.last_image())
+            renderer.change_filter(self.filter2)
+            self.assertIsNone(renderer.last_image())
+            renderer.render(scene=self.scene, geometry=self.geometry)
+            img2 = renderer.last_image()
+            self.assertIsNone(img2)
+            renderer.change_filter(self.filter1)
+            img1 = renderer.last_image()
+            self.assertIsNone(img1)
+
+
+class ImageFilterRendererRenderTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # object
+        p0 = Coordinates3D((-1.0, -1.0, 0.0))
+        p1 = Coordinates3D((-1.0, +1.0, 0.0))
+        p2 = Coordinates3D((+1.0, -1.0, 0.0))
+        obj = Object()
+        obj.add_face(Face(p0, p1, p2))
+        # camera
+        loc = Coordinates3D((0.0, 0.0, -1.0))
+        domain = Domain1D(-1.0, 1.0)
+        manifold = Plane(
+            AbstractVector((1.0, 0.0, 0.0)),
+            AbstractVector((0.0, 1.0, 0.0)),
+            x0_domain=domain,
+            x1_domain=domain,
+        )
+        dim = 10
+        cam = Camera(
+            location=loc,
+            detector_manifold=manifold,
+            canvas_dimensions=(dim, dim),
+        )
+        # scene
+        self.scene = Scene(camera=cam)
+        self.scene.add_object(obj)
+        # geometry
+        self.geometry = CarthesianGeometry()
+        # filter
+        self.filter = HitFilter()
+        # renderer
+        self.renderers = tuple(
+            ImageFilterRenderer(projection_mode=mode, filtr=self.filter)
+            for mode in ProjectionMode
+        )
+
+    def test_image_filter_renderer_render(self) -> None:
+        """Tests render."""
+        for renderer in self.renderers:
+            self.assertTrue(renderer.last_image() is None)
+            renderer.render(scene=self.scene, geometry=self.geometry)
+            self.assertTrue(renderer.last_image() is not None)
+
+
+class ImageFilterProjectionTest(unittest.TestCase):
+    def assertGrayPixel(self, rgb: tuple[int, int, int]) -> None:
+        """Asserts the RGB triple is gray."""
+        self.assertTrue(rgb[0] == rgb[1] == rgb[2])
+
+    def setUp(self) -> None:
+        # object
+        p0 = Coordinates3D((-1.0, -1.0, 0.0))
+        p1 = Coordinates3D((-1.0, +1.0, 0.0))
+        p2 = Coordinates3D((+1.0, -1.0, 0.0))
+        p3 = Coordinates3D((+1.0, +1.0, 0.0))
+        obj = Object(color=Colors.GRAY)
+        obj.add_face(Face(p0, p1, p3))
+        obj.add_face(Face(p0, p2, p3))
+        # camera
+        loc = Coordinates3D((0.0, 0.0, -1.0))
+        domain = Domain1D(-2.0, 2.0)
+        manifold = Plane(
+            AbstractVector((1.0, 0.0, 0.0)),
+            AbstractVector((0.0, 1.0, 0.0)),
+            x0_domain=domain,
+            x1_domain=domain,
+        )
+        dim = 25
+        cam = Camera(
+            location=loc,
+            detector_manifold=manifold,
+            canvas_dimensions=(dim, dim),
+        )
+        # scene
+        self.scene = Scene(camera=cam)
+        self.scene.add_object(obj)
+        # geometry
+        self.geometry = CarthesianGeometry()
+        # filter
+        self.filter = HitFilter()
+        # renderers
+        self.renderer_ortho = ImageFilterRenderer(
+            projection_mode=ProjectionMode.ORTHOGRAPHIC, filtr=self.filter
+        )
+        self.renderer_persp = ImageFilterRenderer(
+            projection_mode=ProjectionMode.PERSPECTIVE, filtr=self.filter
+        )
+
+        # expected outcome in othographic and perspective projection:
+        # +-------------------------+   ^      ^
+        # |                         |   |   ~dim/4
+        # |       +---------+       |   |      V
+        # |       | | | | | |       |   |      ^
+        # |       | | | | | |       |  dim   ~dim/2
+        # |       | | | | | |       |   |      V
+        # |       +---------+       |   |      ^
+        # |                         |   |    ~dim/4
+        # +-------------------------+   V      V
+        # <-----------dim----------->
+        # <~dim/4><--~dim/2-><~dim/4>
+
+        # make list of pixel position inside a square of the given size
+        def pixel_grid(size: float) -> list[tuple[int, int]]:
+            return [
+                (int(dim * (0.5 + x * size)), int(dim * (0.5 + y * size)))
+                for x in (-1, 0, +1)
+                for y in (-1, 0, +1)
+            ]
+
+        # make list of pixel position outlining a square of the given size
+        def pixel_rect(size: float) -> list[tuple[int, int]]:
+            return [
+                (int(dim * (0.5 + x * size)), int(dim * (0.5 + y * size)))
+                for x in (-1, 0, +1)
+                for y in (-1, 0, +1)
+                if not (x == 0 and y == 0)
+            ]
+
+        self.hit_pixel = pixel_grid(0.2)
+        self.no_intersection_pixel = pixel_rect(0.3)
+
+    def test_image_filter_renderer_orthographic(self) -> None:
+        """Tests orthographic projection."""
+        renderer = self.renderer_ortho
+        renderer.render(scene=self.scene, geometry=self.geometry)
+        renderer.apply_filter()
+        img = renderer.last_image()
+        self.assertTrue(img is not None)
+        if img is not None:
+            for pix in self.hit_pixel:
+                self.assertTrue(
+                    img.getpixel(pix) == self.filter.color_hit().rgb
+                )
+            for pix in self.no_intersection_pixel:
+                self.assertTrue(
+                    img.getpixel(pix)
+                    == self.filter.color_miss_reason(
+                        IntersectionInfo.MissReason.NO_INTERSECTION
+                    ).rgb
+                )
+
+    def test_image_filter_renderer_perspective(self) -> None:
+        """Tests perspective projection."""
+        # renderer
+        renderer = self.renderer_persp
+        renderer.render(scene=self.scene, geometry=self.geometry)
+        renderer.apply_filter()
+        img = renderer.last_image()
+        self.assertTrue(img is not None)
+        if img is not None:
+            for pix in self.hit_pixel:
+                self.assertTrue(
+                    img.getpixel(pix) == self.filter.color_hit().rgb
+                )
+            for pix in self.no_intersection_pixel:
+                self.assertTrue(
+                    img.getpixel(pix)
+                    == self.filter.color_miss_reason(
+                        IntersectionInfo.MissReason.NO_INTERSECTION
+                    ).rgb
+                )
+
+
+class ImageFilterRendererProjectionFailureTest1(unittest.TestCase):
+    def setUp(self) -> None:
+        # camera
+        loc = Coordinates3D((0.0, 0.0, 0.0))
+        domain = Domain1D(-1.0, 1.0)
+        # manifold with invalid coordinates for pixel (0,0)
+        manifold = PlaneCylindrical(
+            AbstractVector((1.0, 0.0, 0.0)),
+            AbstractVector((0.0, 1.0, 0.0)),
+            x0_domain=domain,
+            x1_domain=domain,
+        )
+        self.dim = 2  # tiny canvas
+        cam = Camera(
+            location=loc,
+            detector_manifold=manifold,
+            canvas_dimensions=(self.dim, self.dim),
+        )
+        # scene
+        self.scene = Scene(camera=cam)
+        # geometry
+        self.geometry = CylindricRungeKuttaGeometry(
+            max_ray_depth=math.inf,
+            step_size=0.1,
+            max_steps=2,
+        )
+        # filter
+        self.filter = HitFilter()
+        # renderers
+        self.renderer = ImageFilterRenderer(
+            projection_mode=ProjectionMode.ORTHOGRAPHIC,
+            filtr=self.filter,
+            print_warings=False,
+        )
+
+    def test_image_filter_renderer_orthographic_failure(self) -> None:
+        """Tests orthographic projection failure."""
+        renderer = self.renderer
+        renderer.render(scene=self.scene, geometry=self.geometry)
+        renderer.apply_filter()
+        img = renderer.last_image()
+        self.assertTrue(img is not None)
+        if img is not None:
+            found_failure_pixel = False
+            for x in range(self.dim):
+                for y in range(self.dim):
+                    if (
+                        img.getpixel((x, y))
+                        == self.filter.color_miss_reason(
+                            IntersectionInfo.MissReason.RAY_INITIALIZED_OUTSIDE_MANIFOLD
+                        ).rgb
+                    ):
+                        found_failure_pixel = True
+            self.assertTrue(found_failure_pixel)
+
+
+class ImageFilterRendererProjectionFailureTest2(unittest.TestCase):
+    def setUp(self) -> None:
+        # camera
+        loc = Coordinates3D((0.0, 0.0, 0.0))
+        domain = Domain1D(-1.0, 1.0)
+        # manifold with invalid coordinates for pixel (0,0)
+        manifold = PlaneCylindrical(
+            AbstractVector((1.0, 0.0, 0.0)),
+            AbstractVector((0.0, 1.0, 0.0)),
+            x0_domain=domain,
+            x1_domain=domain,
+            offset=AbstractVector((0.0, 0.0, 1.0)),
+        )
+        dim = 1  # single pixel corresponding to (0.0, 0.0, 0.0)
+        cam = Camera(
+            location=loc,
+            detector_manifold=manifold,
+            canvas_dimensions=(dim, dim),
+        )
+        # scene
+        self.scene = Scene(camera=cam)
+        # geometry
+        self.geometry = CylindricRungeKuttaGeometry(
+            max_ray_depth=math.inf,
+            step_size=0.1,
+            max_steps=2,
+        )
+        # filter
+        self.filter = HitFilter()
+        # renderers
+        self.renderer = ImageFilterRenderer(
+            projection_mode=ProjectionMode.PERSPECTIVE,
+            filtr=self.filter,
+            print_warings=False,
+        )
+
+    def test_image_filter_renderer_perspective_failure(self) -> None:
+        """Tests perspective projection failrue."""
+        renderer = self.renderer
+        renderer.render(scene=self.scene, geometry=self.geometry)
+        renderer.apply_filter()
+        img = renderer.last_image()
+        self.assertTrue(img is not None)
+        if img is not None:
+            self.assertTrue(
+                img.getpixel((0, 0))
+                == self.filter.color_miss_reason(
+                    IntersectionInfo.MissReason.RAY_INITIALIZED_OUTSIDE_MANIFOLD
+                ).rgb
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/nerte/render/image_ray_depth_renderer_unittest.py
+++ b/src/nerte/render/image_ray_depth_renderer_unittest.py
@@ -31,7 +31,6 @@ class ImageRayDepthRendererConstructorTest(unittest.TestCase):
         self.invalid_ray_depths = (math.inf, math.nan, -1e-8, -1.0)
 
     def test_image_ray_Depth_renderer_costructor(self) -> None:
-        # pylint: disable=R0201
         """Tests constructor."""
 
         # preconditions

--- a/src/nerte/render/meta_info_filter.py
+++ b/src/nerte/render/meta_info_filter.py
@@ -1,0 +1,104 @@
+"""
+Module for the ray meta info filter - a false-color filter to display the raw ray meta data.
+"""
+
+from typing import cast
+
+import math
+from PIL import Image
+
+from nerte.values.color import Color, Colors
+from nerte.values.intersection_info import IntersectionInfo
+from nerte.values.extended_intersection_info import ExtendedIntersectionInfo
+from nerte.render.image_filter_renderer import (
+    IntersectionInfoMatrix,
+    Filter,
+    color_for_normalized_value,
+)
+
+
+def _clip(value: float) -> float:
+    """
+    Returns value clipped to 0.0 ... 1.0.
+
+    Note: Value must be finite.
+    """
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+class MetaInfoFilter(Filter):
+    """
+    False-color filter for displaying meta info of rays.
+
+    Note: Providing meta info is optional and only one meta info attribute
+          can be filtered for at a time.
+    """
+
+    def __init__(
+        self,
+        meta_data_key: str,
+        min_value: float,
+        max_value: float,
+    ):
+        if not -math.inf < min_value < math.inf:
+            raise ValueError(
+                f"Cannot create meta info filter with min_value={min_value}."
+                f" Value must be finite."
+            )
+        if not -math.inf < max_value < math.inf:
+            raise ValueError(
+                f"Cannot create meta info filter with max_value={max_value}."
+                f" Value must be finite."
+            )
+        if min_value == max_value:
+            raise ValueError(
+                f"Cannot create meta info filter with min_value={min_value} and"
+                f" max_value={max_value}. Values must be different."
+            )
+        self.meta_data_key = meta_data_key
+        self.min_value = min_value
+        self.max_value = max_value
+        self.color_no_meta_data = Color(0, 255, 255)
+
+    def color_for_info(self, info: IntersectionInfo) -> Color:
+        """Returns color for intersection info."""
+
+        if not isinstance(info, ExtendedIntersectionInfo):
+            return self.color_no_meta_data
+        info = cast(ExtendedIntersectionInfo, info)
+
+        if info.meta_data is not None:
+            if self.meta_data_key in info.meta_data:
+                value = info.meta_data[self.meta_data_key] - self.min_value
+                value /= self.max_value - self.min_value
+                value = _clip(value)
+                return color_for_normalized_value(value)
+        return self.color_no_meta_data
+
+    def apply(self, info_matrix: IntersectionInfoMatrix) -> Image:
+        if len(info_matrix) == 0 or len(info_matrix[0]) == 0:
+            raise ValueError(
+                "Cannot apply meta data filter. Intersection info matrix is"
+                " empty."
+            )
+        width = len(info_matrix)
+        height = len(info_matrix[0])
+
+        # initialize image with pink background
+        image = Image.new(
+            mode="RGB", size=(width, height), color=Colors.BLACK.rgb
+        )
+
+        # paint-in pixels
+        for pixel_x in range(width):
+            for pixel_y in range(height):
+                pixel_location = (pixel_x, pixel_y)
+                info = info_matrix[pixel_x][pixel_y]
+                pixel_color = self.color_for_info(info)
+                image.putpixel(pixel_location, pixel_color.rgb)
+
+        return image

--- a/src/nerte/render/meta_info_unittest.py
+++ b/src/nerte/render/meta_info_unittest.py
@@ -1,0 +1,141 @@
+# pylint: disable=R0801
+# pylint: disable=C0103
+# pylint: disable=C0114
+# pylint: disable=C0115
+# pylint: disable=C0144
+
+import unittest
+
+import math
+
+from nerte.values.color import Color
+from nerte.values.intersection_info import IntersectionInfo
+from nerte.values.extended_intersection_info import ExtendedIntersectionInfo
+from nerte.render.image_filter_renderer import IntersectionInfoMatrix
+from nerte.render.meta_info_filter import MetaInfoFilter
+
+
+class MetaInfoFilterConstructorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.meta_data_keys = ("", "a", "B")
+        self.valid_values = (-1.0, 0.0, 1.0)
+        self.invalid_values = (math.inf, math.nan, -math.inf)
+
+    def test_constructor(self) -> None:
+        """Tests the constructor."""
+
+        for key in self.meta_data_keys:
+            for min_val in self.valid_values:
+                for max_val in self.valid_values:
+                    if min_val == max_val:
+                        with self.assertRaises(ValueError):
+                            MetaInfoFilter(
+                                meta_data_key=key,
+                                min_value=min_val,
+                                max_value=max_val,
+                            )
+                    else:
+                        MetaInfoFilter(
+                            meta_data_key=key,
+                            min_value=min_val,
+                            max_value=max_val,
+                        )
+        # invalid
+        for key in self.meta_data_keys:
+            for min_val in self.invalid_values:
+                for max_val in self.valid_values:
+                    with self.assertRaises(ValueError):
+                        MetaInfoFilter(
+                            meta_data_key=key,
+                            min_value=min_val,
+                            max_value=max_val,
+                        )
+            for min_val in self.valid_values:
+                for max_val in self.invalid_values:
+                    with self.assertRaises(ValueError):
+                        MetaInfoFilter(
+                            meta_data_key=key,
+                            min_value=min_val,
+                            max_value=max_val,
+                        )
+
+
+class MetaInfoFilterProperties(unittest.TestCase):
+    def setUp(self) -> None:
+        self.key = "key"
+        self.min_val = 0.0
+        self.max_val = 1.0
+        self.filter = MetaInfoFilter(
+            meta_data_key=self.key,
+            min_value=self.min_val,
+            max_value=self.max_val,
+        )
+
+    def test_properties(self) -> None:
+        """Tests properties."""
+        self.assertIs(self.filter.meta_data_key, self.key)
+        self.assertAlmostEqual(self.filter.min_value, self.min_val)
+        self.assertAlmostEqual(self.filter.max_value, self.max_val)
+        self.assertTupleEqual(self.filter.color_no_meta_data.rgb, (0, 255, 255))
+
+
+class MetaInfoFilterColorForInfoTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.infos = (
+            IntersectionInfo(ray_depth=0.3),
+            ExtendedIntersectionInfo(ray_depth=0.3),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 0.0}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 1.0}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 1.5}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 2.0}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 3.0}),
+        )
+        self.filter = MetaInfoFilter(
+            meta_data_key="key", min_value=1.0, max_value=2.0
+        )
+        self.colors = (
+            self.filter.color_no_meta_data,
+            self.filter.color_no_meta_data,
+            self.filter.color_no_meta_data,
+            Color(0, 0, 0),
+            Color(0, 0, 0),
+            Color(127, 127, 127),
+            Color(255, 255, 255),
+            Color(255, 255, 255),
+        )
+
+    def test_color_for_info(self) -> None:
+        """Tests the color for an intersection information."""
+        for info, col in zip(self.infos, self.colors):
+            c = self.filter.color_for_info(info)
+            self.assertTupleEqual(c.rgb, col.rgb)
+
+
+class MetaInfoFilterApplyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.infos = (
+            IntersectionInfo(ray_depth=0.3),
+            ExtendedIntersectionInfo(ray_depth=0.3),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 0.0}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 0.5}),
+            ExtendedIntersectionInfo(ray_depth=0.3, meta_data={"key": 1.0}),
+        )
+        self.info_matrix = IntersectionInfoMatrix([list(self.infos)])
+        self.filter = MetaInfoFilter(
+            meta_data_key="key", min_value=0.0, max_value=1.0
+        )
+
+    def test_apply(self) -> None:
+        """Test filter application."""
+        image = self.filter.apply(info_matrix=self.info_matrix)
+        for pixel_y, info in enumerate(self.infos):
+            self.assertTupleEqual(
+                image.getpixel((0, pixel_y)),
+                self.filter.color_for_info(info).rgb,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/nerte/render/ray_depth_filter.py
+++ b/src/nerte/render/ray_depth_filter.py
@@ -178,7 +178,7 @@ class RayDepthFilter(Filter):
     def apply(self, info_matrix: IntersectionInfoMatrix) -> Image:
         if len(info_matrix) == 0 or len(info_matrix[0]) == 0:
             raise ValueError(
-                "Cannot apply hit filter. Intersection info matrix is empty."
+                "Cannot apply ray depth filter. Intersection info matrix is empty."
             )
         width = len(info_matrix)
         height = len(info_matrix[0])

--- a/src/nerte/render/ray_depth_filter.py
+++ b/src/nerte/render/ray_depth_filter.py
@@ -31,8 +31,6 @@ class RayDepthFilter(Filter):
         min_ray_depth: Optional[float] = None,
         max_ray_depth: Optional[float] = None,
         max_color_value: float = 1.0,
-        color_failure: Color = Color(255, 0, 255),
-        color_no_intersection: Color = Color(0, 0, 255),
     ):
         if min_ray_depth is not None and not 0.0 <= min_ray_depth < math.inf:
             raise ValueError(
@@ -65,8 +63,6 @@ class RayDepthFilter(Filter):
         self.min_ray_depth = min_ray_depth
         self.max_ray_depth = max_ray_depth
         self.max_color_value = max_color_value  # 0.0...1.0
-        self.color_failure = color_failure
-        self.color_no_intersection = color_no_intersection
 
     def _normalized_ray_depths(self, ray_depths: np.ndarray) -> np.ndarray:
         """
@@ -132,16 +128,9 @@ class RayDepthFilter(Filter):
 
     def color_for_normalized_ray_depth_value(self, value: float) -> Color:
         """
-        Returns color assosiated with ray depth value.
-
-        Infinite ray depth value is assisiated with color_no_intersection.
-        NaN ray depth value is assisiated with color_failure.
+        Returns color assosiated with the normalized ray depth value in
+        [0.0...1.0].
         """
-
-        if np.isnan(value):
-            return self.color_failure
-        if np.isinf(value):
-            return self.color_no_intersection
         if not 0.0 <= value <= 1.0:
             raise ValueError(
                 f"Cannot obtain color from normalized ray depth value {value}."

--- a/src/nerte/render/ray_depth_filter.py
+++ b/src/nerte/render/ray_depth_filter.py
@@ -1,0 +1,220 @@
+"""
+Module for the ray depth filter - a false-color filter to display the raw ray depth data.
+"""
+
+
+from typing import Optional
+
+import math
+import numpy as np
+from PIL import Image
+
+from nerte.values.color import Color, Colors
+from nerte.values.intersection_info import IntersectionInfo
+from nerte.render.image_filter_renderer import IntersectionInfoMatrix, Filter
+
+
+def _is_finite(mat: np.ndarray) -> np.ndarray:
+    """Return boolean matrix where True indicates a finite value."""
+    return np.logical_and(
+        np.logical_not(np.isnan(mat)), np.logical_not(np.isinf(mat))
+    )
+
+
+class RayDepthFilter(Filter):
+    """
+    False-color filter for displaying rays based their depth.
+    """
+
+    def __init__(  # pylint: disable=R0913
+        self,
+        min_ray_depth: Optional[float] = None,
+        max_ray_depth: Optional[float] = None,
+        max_color_value: float = 1.0,
+        color_failure: Color = Color(255, 0, 255),
+        color_no_intersection: Color = Color(0, 0, 255),
+    ):
+        if min_ray_depth is not None and not 0.0 <= min_ray_depth < math.inf:
+            raise ValueError(
+                f"Cannot construct ray depth filter with"
+                f" min_ray_depth={min_ray_depth}. Value must be positive or zero."
+            )
+        if max_ray_depth is not None and not 0.0 <= max_ray_depth < math.inf:
+            raise ValueError(
+                f"Cannot construct ray depth filter with"
+                f" max_ray_depth={max_ray_depth}. Value must be positive or zero."
+            )
+        if (
+            min_ray_depth is not None
+            and max_ray_depth is not None
+            and min_ray_depth >= max_ray_depth
+        ):
+            raise ValueError(
+                f"Cannot construct ray depth filter with"
+                f" min_ray_depth={min_ray_depth} and max_ray_depth={max_ray_depth}."
+                f" min_ray_depth must be smaller than max_ray_depth."
+            )
+        if not 0.0 < max_color_value <= 1.0:
+            raise ValueError(
+                f"Cannot construct ray depth filter with"
+                f" max_color_value={max_color_value}."
+                f" Value must be in between 0.0 (excluding) and 1.0"
+                f" (including)."
+            )
+
+        self.min_ray_depth = min_ray_depth
+        self.max_ray_depth = max_ray_depth
+        self.max_color_value = max_color_value  # 0.0...1.0
+        self.color_failure = color_failure
+        self.color_no_intersection = color_no_intersection
+
+    def _normalized_ray_depths(self, ray_depths: np.ndarray) -> np.ndarray:
+        """
+        Returns ray depth matrix normalized to values from zero to one on a
+        logarithmic scale.
+
+        The minimal and maximal ray depth is either calculated from the inupt
+        or overwritten by the renderer iff it provides min_ray_depth or
+        max_ray_depth respectively.
+
+        Note: inf and nan values are preserved.
+        """
+
+        # add float epsilon to avoid 0.0 due to usage of log
+        ray_depths = ray_depths + np.finfo(float).eps
+        # use logarithmic scale (inf and nan are preserved)
+        ray_depths = np.log(ray_depths)
+
+        # boolean matrix where True indicates a finite value
+        finite_values = _is_finite(ray_depths)
+
+        # calculate min and max ray depth
+        if self.min_ray_depth is None:
+            min_ray_depth = np.min(  # type: ignore[no-untyped-call]
+                ray_depths,
+                where=finite_values,
+                initial=np.inf,
+            )
+        else:
+            # overwrite
+            min_ray_depth = self.min_ray_depth
+        if self.max_ray_depth is None:
+            max_ray_depth = np.max(  # type: ignore[no-untyped-call]
+                ray_depths,
+                where=finite_values,
+                initial=0.0,
+            )
+        else:
+            # overwrite
+            max_ray_depth = self.max_ray_depth
+
+        min_ray_depth, max_ray_depth = min(min_ray_depth, max_ray_depth), max(
+            min_ray_depth, max_ray_depth
+        )
+
+        if np.isinf(max_ray_depth):
+            # all pixels are either inf or nan (no normalization needed)
+            return ray_depths
+
+        # normalize all finite values to [0.0, 1.0]
+        ray_depth_values = (ray_depths - min_ray_depth) / (
+            max_ray_depth - min_ray_depth
+        )
+        # NOTE: Must use out prameter or inf and nan are not preserved!
+        np.clip(
+            ray_depth_values,
+            0.0,
+            1.0,
+            where=finite_values,
+            out=ray_depth_values,  # must use this!
+        )
+        return ray_depth_values
+
+    def color_for_normalized_ray_depth_value(self, value: float) -> Color:
+        """
+        Returns color assosiated with ray depth value.
+
+        Infinite ray depth value is assisiated with color_no_intersection.
+        NaN ray depth value is assisiated with color_failure.
+        """
+
+        if np.isnan(value):
+            return self.color_failure
+        if np.isinf(value):
+            return self.color_no_intersection
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                f"Cannot obtain color from normalized ray depth value {value}."
+                f" Value must be between 0.0 and 1.0 inf or nan."
+            )
+        level = int(value * self.max_color_value * 255)
+        return Color(level, level, level)
+
+    def color_miss_reason(
+        self, miss_reason: IntersectionInfo.MissReason
+    ) -> Color:
+        """
+        Returns a color for a pixel to denote a ray failing to hit a surface.
+        """
+        # pylint: disable=R0201
+        if miss_reason is IntersectionInfo.MissReason.UNINIALIZED:
+            return Color(0, 0, 0)
+        if miss_reason is IntersectionInfo.MissReason.NO_INTERSECTION:
+            return Color(0, 0, 255)
+        if miss_reason is IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD:
+            return Color(0, 255, 0)
+        if (
+            miss_reason
+            is IntersectionInfo.MissReason.RAY_INITIALIZED_OUTSIDE_MANIFOLD
+        ):
+            return Color(255, 255, 0)
+        raise NotImplementedError(
+            f"Cannot pick color for miss reason {miss_reason}."
+            f"No color was implemented."
+        )
+
+    def _color_for_pixel(
+        self, info: IntersectionInfo, pixel_value: float
+    ) -> Color:
+        if info.hits():
+            return self.color_for_normalized_ray_depth_value(pixel_value)
+        miss_reason = info.miss_reason()
+        if miss_reason is None:
+            raise RuntimeError(
+                f"Cannot pick color for intersectio info {info}."
+                " No miss reason specified despite ray is missing."
+            )
+        return self.color_miss_reason(miss_reason)
+
+    def apply(self, info_matrix: IntersectionInfoMatrix) -> Image:
+        if len(info_matrix) == 0 or len(info_matrix[0]) == 0:
+            raise ValueError(
+                "Cannot apply hit filter. Intersection info matrix is empty."
+            )
+        width = len(info_matrix)
+        height = len(info_matrix[0])
+
+        # initialize image with pink background
+        image = Image.new(
+            mode="RGB", size=(width, height), color=Colors.BLACK.rgb
+        )
+        # convert info matrix to ray depth matrix
+        ray_depths_raw = np.full((width, height), math.nan)
+        for pixel_x in range(width):
+            for pixel_y in range(height):
+                info = info_matrix[pixel_x][pixel_y]
+                if info.hits():
+                    ray_depths_raw[pixel_x, pixel_y] = info.ray_depth()
+
+        ray_depth_normalized = self._normalized_ray_depths(ray_depths_raw)
+
+        # paint-in pixels
+        for pixel_x in range(width):
+            for pixel_y in range(height):
+                pixel_location = (pixel_x, pixel_y)
+                info = info_matrix[pixel_x][pixel_y]
+                pixel_value = ray_depth_normalized[pixel_x, pixel_y]
+                pixel_color = self._color_for_pixel(info, pixel_value)
+                image.putpixel(pixel_location, pixel_color.rgb)
+
+        return image

--- a/src/nerte/render/ray_depth_filter_unittest.py
+++ b/src/nerte/render/ray_depth_filter_unittest.py
@@ -81,10 +81,6 @@ class RayDpethFilterProperties(unittest.TestCase):
             max_color_value=0.5,
         )
         self.color = Color(12, 34, 56)
-        self.filter_color_failure = RayDepthFilter(color_failure=self.color)
-        self.filter_color_no_intersection = RayDepthFilter(
-            color_no_intersection=self.color
-        )
 
     def test_default_properties(self) -> None:
         """Tests the default properties."""
@@ -105,16 +101,6 @@ class RayDpethFilterProperties(unittest.TestCase):
     def test_max_color_value(self) -> None:
         """Tests the max color value property."""
         self.assertTrue(self.filter_max_color_value.max_color_value == 0.5)
-
-    def test_colors(self) -> None:
-        """Tests the color properties."""
-        self.assertTrue(
-            self.filter_color_failure.color_failure.rgb == self.color.rgb
-        )
-        self.assertTrue(
-            self.filter_color_no_intersection.color_no_intersection.rgb
-            == self.color.rgb
-        )
 
 
 class RayDepthFilterColorsMissReasonTest(unittest.TestCase):
@@ -169,12 +155,6 @@ class RayDepthFilterColorForRayDepthTest(unittest.TestCase):
                 self.assertAlmostEqual(
                     rgb[0], int(val * filtr.max_color_value * 255)
                 )
-
-            color = filtr.color_for_normalized_ray_depth_value(math.nan)
-            self.assertTrue(color.rgb == filtr.color_failure.rgb)
-
-            color = filtr.color_for_normalized_ray_depth_value(math.inf)
-            self.assertTrue(color.rgb, filtr.color_no_intersection.rgb)
 
             for val in self.invalid_normalized_values:
                 with self.assertRaises(ValueError):

--- a/src/nerte/render/ray_depth_filter_unittest.py
+++ b/src/nerte/render/ray_depth_filter_unittest.py
@@ -1,0 +1,217 @@
+# pylint: disable=R0801
+# pylint: disable=C0103
+# pylint: disable=C0114
+# pylint: disable=C0115
+# pylint: disable=C0144
+
+import unittest
+
+import math
+
+from nerte.values.color import Color
+from nerte.values.intersection_info import IntersectionInfo
+from nerte.render.image_filter_renderer import IntersectionInfoMatrix
+from nerte.render.ray_depth_filter import RayDepthFilter
+
+
+class RayDepthFilterConstructorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # ray depth parameters
+        self.valid_ray_depths = (None, 0.0, 1e-8, 1.0, 1e8)
+        self.invalid_ray_depths = (math.inf, math.nan, -1e-8, -1.0)
+        # max color calue
+        self.valid_max_color_value = (0.1, 0.5, 1.0)
+        self.invalid_max_color_value = (math.inf, math.nan, 0.0, -1.0)
+
+    def test_constructor(self) -> None:
+        """Tests the constructor."""
+
+        # preconditions
+        self.assertTrue(len(self.valid_ray_depths) > 0)
+        self.assertTrue(len(self.invalid_ray_depths) > 0)
+
+        RayDepthFilter()
+
+        # min/max ray depth
+        for min_rd in self.valid_ray_depths:
+            RayDepthFilter(min_ray_depth=min_rd)
+        for max_rd in self.valid_ray_depths:
+            RayDepthFilter(max_ray_depth=max_rd)
+        for min_rd in self.valid_ray_depths:
+            for max_rd in self.valid_ray_depths:
+                if (
+                    min_rd is not None
+                    and max_rd is not None
+                    and max_rd <= min_rd
+                ):
+                    with self.assertRaises(ValueError):
+                        RayDepthFilter(
+                            min_ray_depth=min_rd,
+                            max_ray_depth=max_rd,
+                        )
+                else:
+                    RayDepthFilter(
+                        min_ray_depth=min_rd,
+                        max_ray_depth=max_rd,
+                    )
+        for min_rd in self.invalid_ray_depths:
+            with self.assertRaises(ValueError):
+                RayDepthFilter(min_ray_depth=min_rd)
+        for max_rd in self.invalid_ray_depths:
+            with self.assertRaises(ValueError):
+                RayDepthFilter(max_ray_depth=max_rd)
+
+        # max color value
+        for max_col_val in self.valid_max_color_value:
+            RayDepthFilter(max_color_value=max_col_val)
+        for max_col_val in self.invalid_max_color_value:
+            with self.assertRaises(ValueError):
+                RayDepthFilter(max_color_value=max_col_val)
+
+
+class RayDpethFilterProperties(unittest.TestCase):
+    def setUp(self) -> None:
+        self.filter_min_ray_depth = RayDepthFilter(
+            min_ray_depth=1.0,
+        )
+        self.filter_max_ray_depth = RayDepthFilter(
+            max_ray_depth=1.0,
+        )
+        self.filter_max_color_value = RayDepthFilter(
+            max_color_value=0.5,
+        )
+        self.color = Color(12, 34, 56)
+        self.filter_color_failure = RayDepthFilter(color_failure=self.color)
+        self.filter_color_no_intersection = RayDepthFilter(
+            color_no_intersection=self.color
+        )
+
+    def test_default_properties(self) -> None:
+        """Tests the default properties."""
+        filtr = RayDepthFilter()
+        self.assertIsNone(filtr.min_ray_depth)
+        self.assertIsNone(filtr.max_ray_depth)
+        self.assertTrue(filtr.max_color_value == 1.0)
+
+    def test_ray_depth(self) -> None:
+        """Tests the ray depth properties."""
+
+        self.assertTrue(self.filter_min_ray_depth.min_ray_depth == 1.0)
+        self.assertIsNone(self.filter_min_ray_depth.max_ray_depth)
+
+        self.assertIsNone(self.filter_max_ray_depth.min_ray_depth)
+        self.assertTrue(self.filter_max_ray_depth.max_ray_depth == 1.0)
+
+    def test_max_color_value(self) -> None:
+        """Tests the max color value property."""
+        self.assertTrue(self.filter_max_color_value.max_color_value == 0.5)
+
+    def test_colors(self) -> None:
+        """Tests the color properties."""
+        self.assertTrue(
+            self.filter_color_failure.color_failure.rgb == self.color.rgb
+        )
+        self.assertTrue(
+            self.filter_color_no_intersection.color_no_intersection.rgb
+            == self.color.rgb
+        )
+
+
+class RayDepthFilterColorsMissReasonTest(unittest.TestCase):
+    def assertAllColorsUnique(self, colors: list[Color]) -> None:
+        """ "Asserts all colors in the list are unique."""
+
+        def all_unique(colors: list[Color]) -> bool:
+            rgbs = []
+            return not any(
+                any(c.rgb == rgb for rgb in rgbs)
+                or rgbs.append(c.rgb)  # type: ignore[func-returns-value]
+                for c in colors
+            )
+
+        try:
+            self.assertTrue(all_unique(colors))
+        except AssertionError as ae:
+            raise AssertionError(
+                f"Colors in list {colors} are not unique."
+            ) from ae
+
+    def setUp(self) -> None:
+        self.filter = RayDepthFilter()
+
+    def test_colors(self) -> None:
+        """Tests the colors for miss reasons."""
+        colors: list[Color] = []
+        for miss_reason in IntersectionInfo.MissReason:
+            colors.append(self.filter.color_miss_reason(miss_reason))
+        self.assertAllColorsUnique(colors)
+
+
+class RayDepthFilterColorForRayDepthTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.valid_normalized_values = (0.0, 0.25, 1.0)
+        self.invalid_normalized_values = (-1.0, 1.1)
+
+        max_color_values = (0.5, 1.0)
+        self.filters = tuple(
+            RayDepthFilter(max_color_value=mcv) for mcv in max_color_values
+        )
+
+    def test_color_for_ray_depth(self) -> None:
+        """Tests the color for a ray depth in default mode."""
+
+        for filtr in self.filters:
+
+            for val in self.valid_normalized_values:
+                color = filtr.color_for_normalized_ray_depth_value(val)
+                rgb = color.rgb
+                self.assertTrue(rgb[0] == rgb[1] == rgb[2])
+                self.assertAlmostEqual(
+                    rgb[0], int(val * filtr.max_color_value * 255)
+                )
+
+            color = filtr.color_for_normalized_ray_depth_value(math.nan)
+            self.assertTrue(color.rgb == filtr.color_failure.rgb)
+
+            color = filtr.color_for_normalized_ray_depth_value(math.inf)
+            self.assertTrue(color.rgb, filtr.color_no_intersection.rgb)
+
+            for val in self.invalid_normalized_values:
+                with self.assertRaises(ValueError):
+                    filtr.color_for_normalized_ray_depth_value(val)
+
+
+class RayDepthFilterApplyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.info_matrix = IntersectionInfoMatrix(
+            [
+                [
+                    IntersectionInfo(ray_depth=math.e ** 0),
+                    IntersectionInfo(ray_depth=math.e ** 1),
+                    IntersectionInfo(ray_depth=math.e ** 2),
+                ]
+                + list(
+                    IntersectionInfo(miss_reason=mr)
+                    for mr in IntersectionInfo.MissReason
+                )
+            ]
+        )
+        self.filter = RayDepthFilter(max_color_value=1.0)
+        self.pixel_colors = [
+            Color(0, 0, 0),
+            Color(127, 127, 127),
+            Color(255, 255, 255),
+        ] + list(
+            self.filter.color_miss_reason(mr)
+            for mr in IntersectionInfo.MissReason
+        )
+
+    def test_apply(self) -> None:
+        """Test filter application."""
+        image = self.filter.apply(info_matrix=self.info_matrix)
+        for pixel_y, pixel_color in enumerate(self.pixel_colors):
+            self.assertTupleEqual(image.getpixel((0, pixel_y)), pixel_color.rgb)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/nerte/values/color.py
+++ b/src/nerte/values/color.py
@@ -8,6 +8,9 @@ class Color:
     def __init__(self, r: int, g: int, b: int) -> None:
         self.rgb: tuple[int, int, int] = (r, g, b)
 
+    def __repr__(self) -> str:
+        return f"Color(r={self.rgb[0]},g={self.rgb[1]},b={self.rgb[2]})"
+
 
 class Colors:
     # pylint: disable=R0903

--- a/src/nerte/values/extended_intersection_info.py
+++ b/src/nerte/values/extended_intersection_info.py
@@ -1,0 +1,24 @@
+"""Module for intersection information with meta data."""
+
+from typing import Optional
+
+import math
+
+from nerte.values.intersection_info import IntersectionInfo
+
+
+class ExtendedIntersectionInfo(IntersectionInfo):
+    # pylint: disable=C0115
+    def __init__(
+        self,
+        ray_depth: float = math.inf,
+        miss_reason: Optional[IntersectionInfo.MissReason] = None,
+        meta_data: Optional[dict[str, float]] = None,
+    ) -> None:
+        IntersectionInfo.__init__(self, ray_depth, miss_reason)
+
+        # Note: Do not restrict the properties of the metadata any further
+        #       as it costs only time to check and is an unneccessary
+        #       restriction. Meta data is meant to be used freely and also
+        #       experimentally.
+        self.meta_data = meta_data

--- a/src/nerte/values/extended_intersection_info_unittest.py
+++ b/src/nerte/values/extended_intersection_info_unittest.py
@@ -1,0 +1,131 @@
+# pylint: disable=R0801
+# pylint: disable=C0103
+# pylint: disable=C0114
+# pylint: disable=C0115
+# pylint: disable=C0144
+
+import unittest
+
+from typing import Optional
+
+import math
+
+from nerte.values.intersection_info import IntersectionInfo
+from nerte.values.extended_intersection_info import ExtendedIntersectionInfo
+
+
+class ExtendedIntersectionInfoConstructorTest(unittest.TestCase):
+    def test_basic_constructor(self) -> None:
+        """Tests basic constructor calls without meta data."""
+        ExtendedIntersectionInfo()
+        ExtendedIntersectionInfo(ray_depth=0.0)
+        ExtendedIntersectionInfo(ray_depth=1.0)
+        ExtendedIntersectionInfo(ray_depth=math.inf)
+        ExtendedIntersectionInfo(ray_depth=math.inf, miss_reason=None)
+        # invalid ray_depth
+        with self.assertRaises(ValueError):
+            ExtendedIntersectionInfo(ray_depth=-1.0)
+        with self.assertRaises(ValueError):
+            ExtendedIntersectionInfo(ray_depth=math.nan)
+        # invalid miss_reasons
+        with self.assertRaises(ValueError):
+            ExtendedIntersectionInfo(
+                ray_depth=1.0,
+                miss_reason=IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD,
+            )
+
+    def test_advanced_constructor(self) -> None:
+        # pylint: disable=R0201
+        """Tests advanced constructor calls with meta data."""
+        ExtendedIntersectionInfo(meta_data={})
+        ExtendedIntersectionInfo(meta_data={"": 0.0})
+        ExtendedIntersectionInfo(meta_data={"a": 1.0})
+        ExtendedIntersectionInfo(meta_data={"a": 1.0, "b": 2.0})
+
+
+class ExtendedIntersectionInfoInheritedPropertiesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.info0 = ExtendedIntersectionInfo()
+        self.ray_depths = (0.0, 1.0, math.inf, math.inf, math.inf)
+        self.miss_reasons = (
+            None,
+            None,
+            IntersectionInfo.MissReason.NO_INTERSECTION,
+            IntersectionInfo.MissReason.NO_INTERSECTION,
+            IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD,
+        )
+        self.infos = tuple(
+            ExtendedIntersectionInfo(ray_depth=rd, miss_reason=mr)
+            for rd, mr in zip(self.ray_depths, self.miss_reasons)
+        )
+
+    def test_inherited_default_properties(self) -> None:
+        """Tests inherited default properties."""
+        self.assertFalse(self.info0.hits())
+        self.assertTrue(self.info0.misses())
+        self.assertTrue(self.info0.ray_depth() == math.inf)
+        reason = self.info0.miss_reason()
+        self.assertIsNotNone(reason)
+        if reason is not None:
+            self.assertIs(reason, IntersectionInfo.MissReason.NO_INTERSECTION)
+
+    def test_inherited_properties(self) -> None:
+        """Tests inherited properties."""
+
+        # preconditions
+        self.assertTrue(len(self.infos) > 0)
+        self.assertTrue(
+            len(self.infos) == len(self.ray_depths) == len(self.miss_reasons)
+        )
+
+        for info, ray_depth, miss_reason in zip(
+            self.infos, self.ray_depths, self.miss_reasons
+        ):
+            self.assertTrue(info.ray_depth() == ray_depth)
+            if ray_depth < math.inf:
+                self.assertTrue(info.hits())
+                self.assertFalse(info.misses())
+                self.assertIsNone(info.miss_reason())
+            else:
+                self.assertFalse(info.hits())
+                self.assertTrue(info.misses())
+                self.assertIs(info.miss_reason(), miss_reason)
+
+
+class ExtendedIntersectionPropertiesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        ray_depths = (0.0, 1.0, math.inf, math.inf, math.inf, math.inf)
+        miss_reasons = (
+            None,
+            None,
+            IntersectionInfo.MissReason.NO_INTERSECTION,
+            IntersectionInfo.MissReason.NO_INTERSECTION,
+            IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD,
+            IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD,
+        )
+        self.meta_datas: tuple[Optional[dict[str, float]], ...] = (
+            None,
+            {},
+            {"": 0.0},
+            {"a": math.nan},
+            {"a": 1.0},
+            {"a": 1.0, "b": 2.0},
+        )
+        self.infos = tuple(
+            ExtendedIntersectionInfo(ray_depth=rd, miss_reason=mr, meta_data=md)
+            for rd, mr, md in zip(ray_depths, miss_reasons, self.meta_datas)
+        )
+
+    def test_meta_data(self) -> None:
+        """Tests meta data attribute."""
+
+        # preconditions
+        self.assertTrue(len(self.infos) > 0)
+        self.assertTrue(len(self.infos) == len(self.meta_datas))
+
+        for info, meta_data in zip(self.infos, self.meta_datas):
+            self.assertTrue(info.meta_data == meta_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/nerte/values/intersection_info.py
+++ b/src/nerte/values/intersection_info.py
@@ -10,10 +10,22 @@ class IntersectionInfo:
     """Represents the outcome of an intersection test of a ray with a face."""
 
     class MissReason(Enum):
+        # TODO: redesign: simple numbers do not reflect the hierachy of the
+        #       miss reasons
+        # E.G.  Ray.has_missreason(miss_reason:Ray.MissReason) -> bool
+        #       with behaviour
+        #       info = Info(miss_reason=RAY_INITIALIZED_OUTSIDE_MANIFOLD)
+        #       info.has_missreason(RAY_INITIALIZED_OUTSIDE_MANIFOLD) == TRUE
+        #       info.has_missreason(RAY_LEFT_MANIFOLD) == TRUE
         """All reasons why an intersection test may have failed."""
 
+        # bit field like values
+        UNINIALIZED = 0
         NO_INTERSECTION = 1
         RAY_LEFT_MANIFOLD = 2
+        # a ray starting outside the manifold is an edge case of
+        # a ray reaching the outside of the manifold
+        RAY_INITIALIZED_OUTSIDE_MANIFOLD = 6  # 4 + 2
 
     # reduce miss reasons to one optinal item
     def __init__(
@@ -82,9 +94,15 @@ class IntersectionInfos:
           to save resources.
     """
 
+    UNINIALIZED = IntersectionInfo(
+        miss_reason=IntersectionInfo.MissReason.UNINIALIZED,
+    )
     NO_INTERSECTION = IntersectionInfo(
         miss_reason=IntersectionInfo.MissReason.NO_INTERSECTION,
     )
     RAY_LEFT_MANIFOLD = IntersectionInfo(
         miss_reason=IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD,
+    )
+    RAY_INITIALIZED_OUTSIDE_MANIFOLD = IntersectionInfo(
+        miss_reason=IntersectionInfo.MissReason.RAY_INITIALIZED_OUTSIDE_MANIFOLD,
     )

--- a/src/nerte/values/intersection_info_unittest.py
+++ b/src/nerte/values/intersection_info_unittest.py
@@ -75,6 +75,16 @@ class IntersectionInfoPropertiesTest(unittest.TestCase):
 
 
 class IntersectionInfosPropertiesTest(unittest.TestCase):
+    def test_constant_uninitialized(self) -> None:
+        """Tests if constant UNINIALIZED is correct."""
+        info = IntersectionInfos.UNINIALIZED
+        self.assertTrue(info.misses())
+        self.assertTrue(math.isinf(info.ray_depth()))
+        reason = info.miss_reason()
+        self.assertIsNotNone(reason)
+        if reason is not None:
+            self.assertIs(reason, IntersectionInfo.MissReason.UNINIALIZED)
+
     def test_constant_no_intersection(self) -> None:
         """Tests if constant NO_INTERSECTION is correct."""
         info = IntersectionInfos.NO_INTERSECTION
@@ -94,6 +104,19 @@ class IntersectionInfosPropertiesTest(unittest.TestCase):
         self.assertIsNotNone(reason)
         if reason is not None:
             self.assertIs(reason, IntersectionInfo.MissReason.RAY_LEFT_MANIFOLD)
+
+    def test_constant_ray_initialized_outside_manifold(self) -> None:
+        """Tests if constant RAY_INITIALIZED_OUTSIDE_MANIFOLD is correct."""
+        info = IntersectionInfos.RAY_INITIALIZED_OUTSIDE_MANIFOLD
+        self.assertTrue(info.misses())
+        self.assertTrue(math.isinf(info.ray_depth()))
+        reason = info.miss_reason()
+        self.assertIsNotNone(reason)
+        if reason is not None:
+            self.assertIs(
+                reason,
+                IntersectionInfo.MissReason.RAY_INITIALIZED_OUTSIDE_MANIFOLD,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
the workflow should be separated as follows:
- processing/render: get intersection info per pixel for all pixels
- post-processing/display: convert this information into an image (can be applied multiple times without rendering again)